### PR TITLE
replace 0.7854 for M_PI/4.0

### DIFF
--- a/Model/FrictionInteraction.cpp
+++ b/Model/FrictionInteraction.cpp
@@ -207,7 +207,7 @@ pair<bool,double> CFrictionInteraction::getAbsFrictionalStress() const
   if(dist<(eq_dist*eq_dist))
   {
           res.first=true;
-          double Ac=eq_dist*eq_dist*0.7854; // contact area
+          double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
           res.second=m_Ffric.norm()/Ac;
   }
   else
@@ -262,7 +262,7 @@ pair<bool,double> CFrictionInteraction::getMaxFricStress() const
     dist=sqrt(dist);
     Vec3 force=D*(m_k*(dist-eq_dist)/dist);
     res.first=true;
-    double Ac=eq_dist*eq_dist*0.7854; // contact area
+    double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
     res.second=force.norm()/Ac;
   }
   else
@@ -291,7 +291,7 @@ pair<bool,double> CFrictionInteraction::getNormalStress() const
   if(m_is_touching){
     res.first=true;
     double eq_dist=m_p1->getRad()+m_p2->getRad();
-    double Ac=eq_dist*eq_dist*0.7854; // contact area
+    double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
     res.second=m_normal_force.norm()/Ac;
   } else {
     res.first=false;

--- a/Model/HertzMindlinInteraction.cpp
+++ b/Model/HertzMindlinInteraction.cpp
@@ -229,7 +229,7 @@ CHertzMindlinInteraction::getAbsFrictionalStress() const
   if(dist<(eq_dist*eq_dist))
   {
     res.first=true;
-    double Ac=eq_dist*eq_dist*0.7854; // contact area
+    double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
     res.second=m_Ffric.norm()/Ac;
   }
   else
@@ -297,7 +297,7 @@ CHertzMindlinInteraction::getMaxFricStress() const
     double norm_force=4.0/3.0*m_E*sqrt(R_ij)*pow(dn,1.5);
     Vec3 force = dir*norm_force;
     res.first=true;
-    double Ac=eq_dist*eq_dist*0.7854; // contact area
+    double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
     res.second=force.norm()/Ac;
   }
   else
@@ -327,7 +327,7 @@ CHertzMindlinInteraction::getNormalStress() const
   if(m_is_touching){
     res.first=true;
     double eq_dist=m_p1->getRad()+m_p2->getRad();
-    double Ac=eq_dist*eq_dist*0.7854; // contact area
+    double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
     res.second=m_normal_force.norm()/Ac;
   } else {
     res.first=false;

--- a/Model/HertzMindlinViscoInteraction.cpp
+++ b/Model/HertzMindlinViscoInteraction.cpp
@@ -256,7 +256,7 @@ CHertzMindlinViscoInteraction::getAbsFrictionalStress() const
   if(dist<(eq_dist*eq_dist))
   {
     res.first=true;
-    double Ac=eq_dist*eq_dist*0.7854; // contact area
+    double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
     res.second=m_Ffric.norm()/Ac;
   }
   else
@@ -341,7 +341,7 @@ CHertzMindlinViscoInteraction::getMaxFricStress() const
     force -= normal_damping;
 
     res.first=true;
-    double Ac=eq_dist*eq_dist*0.7854; // contact area
+    double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
     res.second=force.norm()/Ac;
   }
   else
@@ -371,7 +371,7 @@ CHertzMindlinViscoInteraction::getNormalStress() const
   if(m_is_touching){
     res.first=true;
     double eq_dist=m_p1->getRad()+m_p2->getRad();
-    double Ac=eq_dist*eq_dist*0.7854; // contact area
+    double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
     res.second=m_normal_force.norm()/Ac;
   } else {
     res.first=false;

--- a/Model/HertzianViscoElasticFrictionInteraction.cpp
+++ b/Model/HertzianViscoElasticFrictionInteraction.cpp
@@ -256,7 +256,7 @@ CHertzianViscoElasticFrictionInteraction::getAbsFrictionalStress() const
   if(dist<(eq_dist*eq_dist))
   {
     res.first=true;
-    double Ac=eq_dist*eq_dist*0.7854; // contact area
+    double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
     res.second=m_Ffric.norm()/Ac;
   }
   else
@@ -351,7 +351,7 @@ CHertzianViscoElasticFrictionInteraction::getMaxFricStress() const
       (pow(dn,1.5)+m_A*sqrt(dn)*m_dn_dot);
     Vec3 force = norm_force < 0 ? Vec3(0.0,0.0,0.0) : dir*norm_force;
     res.first=true;
-    double Ac=eq_dist*eq_dist*0.7854; // contact area
+    double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
     res.second=force.norm()/Ac;
   }
   else
@@ -381,7 +381,7 @@ CHertzianViscoElasticFrictionInteraction::getNormalStress() const
   if(m_is_touching){
     res.first=true;
     double eq_dist=m_p1->getRad()+m_p2->getRad();
-    double Ac=eq_dist*eq_dist*0.7854; // contact area
+    double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
     res.second=m_normal_force.norm()/Ac;
   } else {
     res.first=false;

--- a/Model/SpringDashpotFrictionInteraction.cpp
+++ b/Model/SpringDashpotFrictionInteraction.cpp
@@ -232,7 +232,7 @@ pair<bool,double> CSpringDashpotFrictionInteraction::getAbsFrictionalStress() co
   if(dist<(eq_dist*eq_dist))
   {
           res.first=true;
-          double Ac=eq_dist*eq_dist*0.7854; // contact area
+          double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
           res.second=m_Ffric.norm()/Ac;
   }
   else
@@ -287,7 +287,7 @@ pair<bool,double> CSpringDashpotFrictionInteraction::getMaxFricStress() const
     dist=sqrt(dist);
     Vec3 force=D*(m_k*(dist-eq_dist)/dist);
     res.first=true;
-    double Ac=eq_dist*eq_dist*0.7854; // contact area
+    double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
     res.second=force.norm()/Ac;
   }
   else
@@ -316,7 +316,7 @@ pair<bool,double> CSpringDashpotFrictionInteraction::getNormalStress() const
   if(m_is_touching){
     res.first=true;
     double eq_dist=m_p1->getRad()+m_p2->getRad();
-    double Ac=eq_dist*eq_dist*0.7854; // contact area
+    double Ac=eq_dist*eq_dist*M_PI/4.0; // contact area
     res.second=m_normal_force.norm()/Ac;
   } else {
     res.first=false;


### PR DESCRIPTION
5) In 
`FrictionInteraction.cpp`
`HertzMindlinInteraction.cpp`
`HertzMindlinViscoInteraction.cpp`
`HertzianViscoElasticFrictionInteraction.cpp`
`SpringDashpotFrictionInteraction.cpp`

`Pi/4` is put as `0.7854` , but it is better to use the machine precision value: `M_PI/4.0`
We change `0.7854` by `M_PI/4.0`

[the related trello card ](https://trello.com/c/mmJd1zJa/19-cambiar-07854-por-mpi-40)
