### PR TITLE
HertzianElastic and HertzianViscoElastic prints 0 on contact point

### DIFF
--- a/Model/HertzianElasticInteraction.cpp
+++ b/Model/HertzianElasticInteraction.cpp
@@ -60,6 +60,7 @@ void CHertzianElasticInteraction::calcForces()
     Vec3 pos=m_p2->getPos()+(m_p2->getRad()/eq_dist)*D;
     m_p1->applyForce(m_force,pos);
     m_p2->applyForce(-1.0*m_force,pos); 
+    m_cpos=pos;
   } else {
     m_force=Vec3(0.0,0.0,0.0);
     m_dn=0.0;

--- a/Model/HertzianViscoElasticInteraction.cpp
+++ b/Model/HertzianViscoElasticInteraction.cpp
@@ -94,6 +94,8 @@ void CHertzianViscoElasticInteraction::calcForces()
     Vec3 pos=m_p2->getPos()+(m_p2->getRad()/eq_dist)*D;
     m_p1->applyForce(m_force,pos);
     m_p2->applyForce(-1.0*m_force,pos); 
+
+    m_cpos=pos;
   } else {
     m_force=Vec3(0.0,0.0,0.0);
     m_dn=0.0;


### PR DESCRIPTION
When using `createFieldSaver` with `InteractionVectorFieldSaverPrms` in `HertzianElastic` and `HertzianViscoElastic` prints `0 0 0` for the position of the contact point between the particles. The sign of the force is okay.

We fix the bug by putting the correct position.

[relate trello card](https://trello.com/c/3XOxVThw/15-hertzianelastic-0-0-0-en-punto-de-toque-entre-part%C3%ADculas)