### PR TITLE
removed empty lines

### DIFF
--- a/Model/BrittleBeamDZC.cpp
+++ b/Model/BrittleBeamDZC.cpp
@@ -298,7 +298,7 @@ void BrittleBeamDZCInteraction::saveRestartData(std::ostream &oStream)
     oStream << m_cohesion << " ";
     oStream << m_tanAngle << " ";
     oStream << m_beta1 << " ";
-    oStream << m_beta2;
+    oStream << m_beta2 << std::endl;
 }
 
 /*!

--- a/Model/BrittleBeamSC.cpp
+++ b/Model/BrittleBeamSC.cpp
@@ -298,7 +298,7 @@ void BrittleBeamSCInteraction::saveRestartData(std::ostream &oStream)
     oStream << getTag() << " ";
     oStream << m_sigma3 << " ";
     oStream << m_cohesion << " ";
-    oStream << m_tanAngle;
+    oStream << m_tanAngle << std::endl;
 }
 
 /*!

--- a/Model/ElasticInteraction.cpp
+++ b/Model/ElasticInteraction.cpp
@@ -190,7 +190,7 @@ void CElasticInteraction::saveRestartData(std::ostream &oStream)
   oStream << m_id[1] << " ";
   oStream << m_init  << " ";
   oStream << m_k << " ";
-  oStream << m_scaling;
+  oStream << m_scaling << std::endl;
 }
 
 /*!

--- a/Model/FrictionInteraction.cpp
+++ b/Model/FrictionInteraction.cpp
@@ -639,7 +639,7 @@ void CFrictionInteraction::saveRestartData(std::ostream &oStream)
   oStream << m_is_touching << " ";
   oStream << m_Ffric.X() << " ";
   oStream << m_Ffric.Y() << " ";
-  oStream << m_Ffric.Z();
+  oStream << m_Ffric.Z() << std::endl;
 }
 
 

--- a/Model/RotBondedInteraction.cpp
+++ b/Model/RotBondedInteraction.cpp
@@ -395,7 +395,7 @@ void CRotBondedInteraction::saveRestartData(std::ostream &oStream)
   oStream << m_max_tMoment << " ";
   oStream << m_max_bMoment << " ";
   oStream << m_D << " ";
-  oStream << getTag() ;
+  oStream << getTag() << std::endl;
 }
 
 /*!

--- a/Model/RotElasticInteraction.cpp
+++ b/Model/RotElasticInteraction.cpp
@@ -163,7 +163,7 @@ void CRotElasticInteraction::saveRestartData(std::ostream &oStream)
   oStream << m_init  << " ";
   oStream << m_kr << " ";
   oStream << m_scaling << " ";
-  oStream << m_D;
+  oStream << m_D << std::endl;
 }
 
 /*!

--- a/Model/RotFricInteraction.cpp
+++ b/Model/RotFricInteraction.cpp
@@ -610,7 +610,7 @@ void CRotFrictionInteraction::saveRestartData(std::ostream &oStream)
   oStream << m_is_touching << " ";
   oStream << m_Ffric.X() << " ";
   oStream << m_Ffric.Y() << " ";
-  oStream << m_Ffric.Z();
+  oStream << m_Ffric.Z() << std::endl;
 }
 
 

--- a/Model/RotThermBondedInteraction.cpp
+++ b/Model/RotThermBondedInteraction.cpp
@@ -971,7 +971,7 @@ void CRotThermBondedInteraction::saveRestartData(std::ostream &oStream)
   oStream << m_max_tMoment << " ";
   oStream << m_max_bMoment << " ";
   oStream << m_diffusivity << " ";
-  oStream << getTag() ;
+  oStream << getTag() << std::endl;
 }
 
 /*!

--- a/Model/RotThermElasticInteraction.cpp
+++ b/Model/RotThermElasticInteraction.cpp
@@ -219,7 +219,7 @@ void CRotThermElasticInteraction::saveRestartData(std::ostream &oStream)
   oStream << m_init  << " ";
   oStream << m_kr << " ";
   oStream << m_diffusivity << " ";
-  oStream << m_D;
+  oStream << m_D << std::endl;
 }
 
 /*!

--- a/Model/RotThermFricInteraction.cpp
+++ b/Model/RotThermFricInteraction.cpp
@@ -507,7 +507,7 @@ void CRotThermFrictionInteraction::saveRestartData(std::ostream &oStream)
   oStream << m_diffusivity << " ";
   oStream << m_ds.X() << " ";
   oStream << m_ds.Y() << " ";
-  oStream << m_ds.Z();
+  oStream << m_ds.Z() << std::endl;
 }
 
 

--- a/Model/SpringDashpotFrictionInteraction.cpp
+++ b/Model/SpringDashpotFrictionInteraction.cpp
@@ -664,7 +664,7 @@ void CSpringDashpotFrictionInteraction::saveRestartData(std::ostream &oStream)
   oStream << m_is_touching << " ";
   oStream << m_Ffric.X() << " ";
   oStream << m_Ffric.Y() << " ";
-  oStream << m_Ffric.Z();
+  oStream << m_Ffric.Z() << std::endl;
 }
 
 

--- a/pis/pi_storage_ed.hpp
+++ b/pis/pi_storage_ed.hpp
@@ -201,18 +201,14 @@ void ParallelInteractionStorage_ED<P,InteractionType>::calcHeatTrans()
 template<typename P,typename InteractionType>
 void ParallelInteractionStorage_ED<P,InteractionType>::saveCheckPointData(std::ostream &oStream)
 {
-  const std::string delim = "\n";
-
   typename ParallelInteractionStorage_E<P,InteractionType>::InteractionIterator it =
     this->getInnerInteractionIterator();
-  oStream << InteractionType::getType() << delim;
+  oStream << InteractionType::getType() << std::endl;
   oStream << it.getNumRemaining();
   if (it.hasNext()) {
-    oStream << delim;
     it.next().saveRestartData(oStream);
     while (it.hasNext())
     {
-      oStream << delim;
       it.next().saveRestartData(oStream);
     }
   }


### PR DESCRIPTION
When using the createRestartCheckPointer in HertzianViscoElasticFriction writes some empty lines after the line with "HertzianViscoElasticFriction".

We have removed the empty line printed for each interaction.